### PR TITLE
ToUnixTime fix

### DIFF
--- a/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
+++ b/InfluxData.Net.Common/Helpers/ObjectExtensions.cs
@@ -43,7 +43,7 @@ namespace InfluxData.Net.Common.Helpers
         /// <returns>Unix-style timestamp in milliseconds.</returns>
         public static long ToUnixTime(this DateTime date)
         {
-            return Convert.ToInt64((date - _epoch).Milliseconds);
+            return Convert.ToInt64((date - _epoch).TotalMilliseconds);
         }
 
         /// <summary>


### PR DESCRIPTION
I changed the ToUnixTime helper method to return the total milliseconds since epoch instead of the milliseconds of the DateTime object. Before this, if the user provided the optional Timestamp in a Point object, the data would be written to InfluxDB as having happened a few milliseconds after the start of epoch.
